### PR TITLE
Map /dev/shm to avoid chrome crash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,7 @@ services:
     image: selenium/standalone-chrome-debug:latest
     volumes:
       - ./test/samples:/var/www/cdms/test/samples
+      - /dev/shm:/dev/shm
     ports:
       - 4444:4444
       - 5900:5900


### PR DESCRIPTION
/dev/shm is nothing but implementation of traditional shared memory concept. It is an efficient means of passing data between programs. One program will create a memory portion, which other processes (if permitted) can access. This will result into speeding up things on Linux.